### PR TITLE
Adjusted autoload.php and config.yml

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -22,10 +22,10 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 if (!function_exists('intl_get_error_code')) {
     require_once __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs/functions.php';
 
-    $loader->add('IntlDateFormatter', __DIR__.'/../vendor/symfony/src/Symfony/Component/Locale/Resources/stubs');
-    $loader->add('Collator', __DIR__.'/../vendor/symfony/src/Symfony/Component/Locale/Resources/stubs');
-    $loader->add('Locale', __DIR__.'/../vendor/symfony/src/Symfony/Component/Locale/Resources/stubs');
-    $loader->add('NumberFormatter', __DIR__.'/../vendor/symfony/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->add('IntlDateFormatter', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->add('Collator', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->add('Locale', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->add('NumberFormatter', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
 }
 
 AnnotationRegistry::registerLoader(function($class) use ($loader) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -80,7 +80,7 @@ doctrine_mongodb:
             options:
                 connect: true
     default_document_manager: default
-    default_database: app_%kernel.environment%
+    default_database: vespolina_%kernel.environment%
     document_managers:
         default:
             #auto_mapping: true


### PR DESCRIPTION
With the latest composer, symfony vendor has a new directory structure. 
This caused that (in my case) the NumberFormatter class couldn't be found, wich caused the Form Validation to die with a fatal error.

NOTE: I also changed the default_database for mongo to `vespolina_%kernel.environment%`, so I can find my database a bit easier :)
