### PR TITLE
Type object already exists. Issue #110

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -14,9 +14,13 @@ class AppKernel extends Kernel
 {
 
     public function boot()
-    {
-        Doctrine\ODM\MongoDB\Types\Type::addType('object', 'Payum\Core\Bridge\Doctrine\Types\ObjectType');
 
+    {
+        if(!Doctrine\ODM\MongoDB\Types\Type::hasType('object'))
+        {
+            Doctrine\ODM\MongoDB\Types\Type::addType('object', 'Payum\Core\Bridge\Doctrine\Types\ObjectType');
+
+        }
         parent::boot();
     }
 


### PR DESCRIPTION
When doing "php app / console cache: clear" error [Doctrine\ODM\MongoDB\Mapping\MappingException]
