### PR TITLE
Vespolina/media is required ! since vespolina/core has changed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "vespolina/admin-bundle": "*",
         "vespolina/commerce-bundle": "dev-master",
         "vespolina/taxation-bundle": "*",
-        "vespolina/store-bundle": "dev-master"
+        "vespolina/store-bundle": "dev-master",
+        "vespolina/media": "*"
     },
     "require-dev": {
         "doctrine/dbal": "~2.3"


### PR DESCRIPTION
Vespolina core bundle has "move Assets to V Media" (e96dfe1) so for the sandbox to run we must include vespolina/media in composer.json. issues  #110 #111
